### PR TITLE
** filters exclude dot files

### DIFF
--- a/lib/generate-filter.js
+++ b/lib/generate-filter.js
@@ -9,7 +9,7 @@ module.exports = function generateFilter (custom) {
     if (custom) {
       for (let filter of custom) {
         if (filter[0] !== '/') filter = '**/' + filter
-        if (minimatch(key, filter, { nocase: true })) return false
+        if (minimatch(key, filter, { nocase: true, dot: true })) return false
       }
     }
 


### PR DESCRIPTION
if a filter is used like `venv/**` it should filter `venv/.path/file` and `venv/path/.path/file` and `venv/path/.file`. prior to this commit these would have not been excluded