### PR TITLE
Adding list command to show keys of drives managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ For security, requests to `/.drives/*` are rejected, so mind the storage locatio
 drives info <my-drive-key>
 ```
 
+#### List drives managed
+```bash
+drives list
+```
+
 ## License
 
 Apache-2.0

--- a/bin.js
+++ b/bin.js
@@ -14,6 +14,7 @@ const get = require('./bin/get.js')
 const rm = require('./bin/rm.js')
 const info = require('./bin/info.js')
 const purge = require('./bin/purge.js')
+const list = require('./bin/list.js')
 
 const program = new Command()
 
@@ -116,5 +117,10 @@ program.command('purge')
   .argument('<key>', 'Drive public key')
   .option('--storage <path>', 'Storage path')
   .action(purge)
+
+program.command('list')
+  .description('List all drives managed in storage')
+  .option('--storage <path>', 'Storage path')
+  .action(list)
 
 program.parseAsync()

--- a/bin/list.js
+++ b/bin/list.js
@@ -1,0 +1,22 @@
+
+const Corestore = require('corestore')
+const Hyperdrive = require('hyperdrive')
+const HypercoreId = require('hypercore-id-encoding')
+const errorAndExit = require('../lib/exit.js')
+const { findCorestore, noticeStorage } = require('../lib/find-corestore.js')
+const fs = require('fs').promises
+
+module.exports = async function cmd(options = {}) {
+  if (options.storage && typeof options.storage !== 'string') errorAndExit('--storage <path> is required as string')
+
+  const storage = await findCorestore(options)
+  await noticeStorage(storage)
+
+  try {
+  console.log((await fs.readFile(storage + '/../drives', 'utf8')).trimEnd())
+  } catch (error) {
+    // if file doesn't exist (ENOENT) there are no drives present in the storage
+    // anyother error is more serious
+    if (error.code != 'ENOENT') throw error
+  }
+}

--- a/bin/touch.js
+++ b/bin/touch.js
@@ -5,6 +5,7 @@ const HypercoreId = require('hypercore-id-encoding')
 const crayon = require('tiny-crayon')
 const errorAndExit = require('../lib/exit.js')
 const { findCorestore, noticeStorage } = require('../lib/find-corestore.js')
+const fs = require('fs').promises
 
 module.exports = async function cmd (options = {}) {
   if (options.storage && typeof options.storage !== 'string') errorAndExit('--storage <path> is required as string')
@@ -18,5 +19,7 @@ module.exports = async function cmd (options = {}) {
   const drive = new Hyperdrive(ns)
   await drive.ready()
 
+  const driveId = HypercoreId.encode(drive.key)
   console.log('New drive:', crayon.magenta(HypercoreId.encode(drive.key)))
+  await fs.appendFile(storage + '/../drives', driveId + '\n')
 }


### PR DESCRIPTION
Fixes https://github.com/holepunchto/drives/issues/19 by storing the drives created using touch command in a file called 'drives'. This file is then listed when 'drives list' is invoked.