### PR TITLE
Efficient live mirror

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -42,6 +42,7 @@ program.command('mirror')
   .option('--silent', 'Print less information')
   .option('--verbose', 'Print more information')
   .option('--storage <path>', 'Storage path')
+  .option('--bootstrap <int>', 'bootstrap port (only relevant for tests)', parseInt)
   .action(mirror)
 
 program.command('ls')

--- a/bin/mirror.js
+++ b/bin/mirror.js
@@ -102,8 +102,6 @@ module.exports = async function cmd (src, dst, options = {}) {
     }
   }
 
-  // TODO: reason on what happens to changes occurring
-  // while mirror() runs, before the watcher iter is consumed
   let watcher = null
   if (options.live) {
     // No need for teardown logic on the watcher (with goodbye handler)

--- a/bin/mirror.js
+++ b/bin/mirror.js
@@ -18,6 +18,11 @@ module.exports = async function cmd (src, dst, options = {}) {
   if (options.storage && typeof options.storage !== 'string') errorAndExit('--storage <path> must be a string')
   if (options.filter && !Array.isArray(options.filter)) errorAndExit('--filter [ignore...] must be an array')
 
+  // For tests, testing on localhost testnet
+  const bootstrap = options.bootstrap
+    ? [{ host: '127.0.0.1', port: options.bootstrap }]
+    : null
+
   const storage = await findCorestore(options)
   await noticeStorage(storage, [src, dst])
 
@@ -42,7 +47,7 @@ module.exports = async function cmd (src, dst, options = {}) {
 
   const hyperdrives = [source, destination].filter(drive => (drive instanceof Hyperdrive))
   if (source instanceof Hyperdrive || (options.live && hyperdrives.length)) {
-    const swarm = new Hyperswarm()
+    const swarm = new Hyperswarm({ bootstrap })
     goodbye(() => swarm.destroy(), 2)
 
     for (const drive of hyperdrives) swarming(swarm, drive, options)

--- a/bin/mirror.js
+++ b/bin/mirror.js
@@ -130,7 +130,6 @@ module.exports = async function cmd (src, dst, options = {}) {
 
       if (await same(srcEntry, tgtEntry, source, destination)) continue
 
-
       const isDelete = srcEntry === null
       const isNew = tgtEntry === null
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "serve-drive": "^2.2.0",
     "tiny-byte-size": "^1.1.0",
     "tiny-crayon": "^1.0.5",
-    "unix-path-resolve": "^1.0.2"
+    "unix-path-resolve": "^1.0.2",
+    "watch-drive": "^2.0.1"
   },
   "devDependencies": {
     "brittle": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "drives": "./bin.js"
   },
   "scripts": {
-    "test": "standard"
+    "test": "standard && npx brittle test.js"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,10 @@
     "unix-path-resolve": "^1.0.2"
   },
   "devDependencies": {
-    "standard": "^17.0.0"
+    "brittle": "^3.5.0",
+    "hyperdht": "^6.14.0",
+    "newline-decoder": "^1.0.2",
+    "standard": "^17.0.0",
+    "test-tmp": "^1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "hyperdrive": "^11.0.1",
     "hyperswarm": "^4.3.7",
     "localdrive": "^1.4.1",
-    "localwatch": "holepunchto/localwatch#add-eager-open-opt",
     "minimatch": "^9.0.0",
     "mirror-drive": "^1.2.2",
     "recursive-watch": "^1.1.4",
@@ -40,7 +39,7 @@
     "tiny-byte-size": "^1.1.0",
     "tiny-crayon": "^1.0.5",
     "unix-path-resolve": "^1.0.2",
-    "watch-drive": "hdegroote/watch-drive#eager-open-opt"
+    "watch-drive": "^2.0.2"
   },
   "devDependencies": {
     "brittle": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/holepunchto/drives",
   "dependencies": {
     "ansi-diff": "^1.1.1",
+    "binary-stream-equals": "^1.0.0",
     "commander": "^9.4.1",
     "corestore": "^6.4.2",
     "debounceify": "^1.0.0",
@@ -30,6 +31,7 @@
     "hyperdrive": "^11.0.1",
     "hyperswarm": "^4.3.7",
     "localdrive": "^1.4.1",
+    "localwatch": "holepunchto/localwatch#add-eager-open-opt",
     "minimatch": "^9.0.0",
     "mirror-drive": "^1.2.2",
     "recursive-watch": "^1.1.4",
@@ -38,7 +40,7 @@
     "tiny-byte-size": "^1.1.0",
     "tiny-crayon": "^1.0.5",
     "unix-path-resolve": "^1.0.2",
-    "watch-drive": "^2.0.1"
+    "watch-drive": "hdegroote/watch-drive#eager-open-opt"
   },
   "devDependencies": {
     "brittle": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "drives": "./bin.js"
   },
   "scripts": {
-    "test": "standard && npx brittle test.js"
+    "test": "standard && brittle test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -79,7 +79,7 @@ test('integration: mirror --live flow', async t => {
           tSetupSource.pass('Source dir is mirrored')
         }
 
-        if (line.includes('new-file.txt')) {
+        if (line.includes('+ /new-file.txt')) {
           tSourceUpdate.pass('Source update detected')
         }
       }
@@ -120,7 +120,7 @@ test('integration: mirror --live flow', async t => {
           tSetupDst.pass('Setup target mirror')
         }
 
-        if (line.includes('new-file.txt')) {
+        if (line.includes('+ /new-file.txt')) {
           tDstUpdate.pass('Target update detected')
         }
       }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,201 @@
+const { spawn } = require('child_process')
+const fsProm = require('fs/promises')
+const path = require('path')
+const createTestnet = require('hyperdht/testnet')
+const tmpDir = require('test-tmp')
+const test = require('brittle')
+const NewlineDecoder = require('newline-decoder')
+const { once } = require('events')
+
+const DEBUG = false
+const EXECUTABLE = path.join(__dirname, 'bin.js')
+
+// To force the process.on('exit') to be called on those exits too
+process.prependListener('SIGINT', () => process.exit(1))
+process.prependListener('SIGTERM', () => process.exit(1))
+
+test('integration: mirror --live flow', async t => {
+  t.comment('One process live mirrors a directory to a hyperdrive, while another process live mirrors that hyperdrive to another directory')
+
+  const { bootstrap } = await createTestnet(3, t.teardown)
+  const bootstrapPort = bootstrap[0].port
+
+  const tSetupSource = t.test('source mirror setup')
+  tSetupSource.plan(1)
+  const tSetupDst = t.test('Destination mirror setup')
+  tSetupDst.plan(1)
+
+  const tSourceUpdate = t.test('source mirror updates')
+  tSourceUpdate.plan(1)
+  const tDstUpdate = t.test('Destination mirror updates')
+  tDstUpdate.plan(1)
+
+  const dir = await tmpDir(t)
+
+  const srcDir = path.join(dir, 'src')
+  await fsProm.mkdir(srcDir)
+  await fsProm.writeFile(
+    path.join(srcDir, 'init-file.txt'),
+    'Just an initial file'
+  )
+  const dstDir = path.join(dir, 'destination')
+  await fsProm.mkdir(dstDir)
+
+  const srcStorage = path.join(dir, 'src-storage')
+  const dstStorage = path.join(dir, 'dst-storage')
+
+  const srcDriveKey = await setupDrive(srcStorage, t)
+
+  const runSrcProc = spawn(process.execPath, [
+    EXECUTABLE,
+    'mirror',
+    '--live',
+    '--storage',
+    srcStorage,
+    '--bootstrap',
+    bootstrapPort,
+    srcDir,
+    srcDriveKey
+
+  ])
+
+  // To avoid zombie processes in case there's an error
+  process.on('exit', () => {
+    runSrcProc.kill('SIGKILL')
+  })
+
+  runSrcProc.stderr.on('data', d => {
+    console.error(d.toString())
+    t.fail('There should be no stderr')
+  })
+
+  {
+    const stdoutDec = new NewlineDecoder('utf-8')
+    runSrcProc.stdout.on('data', d => {
+      if (DEBUG) console.log(d.toString())
+
+      for (const line of stdoutDec.push(d)) {
+        if (line.includes('Total files: 1')) {
+          tSetupSource.pass('Source dir is mirrored')
+        }
+
+        if (line.includes('new-file.txt')) {
+          tSourceUpdate.pass('Source update detected')
+        }
+      }
+    })
+  }
+
+  await tSetupSource
+
+  const runTgtProc = spawn(process.execPath, [
+    EXECUTABLE,
+    'mirror',
+    '--live',
+    '--storage',
+    dstStorage,
+    '--bootstrap',
+    bootstrapPort,
+    srcDriveKey,
+    dstDir
+  ])
+
+  // To avoid zombie processes in case there's an error
+  process.on('exit', () => {
+    if (runTgtProc.exitCode === null) runTgtProc.kill('SIGKILL')
+  })
+
+  runTgtProc.stderr.on('data', d => {
+    console.error(d.toString())
+    t.fail('There should be no stderr')
+  })
+
+  {
+    const stdoutDec = new NewlineDecoder('utf-8')
+    runTgtProc.stdout.on('data', d => {
+      if (DEBUG) console.log('<target process>', d.toString())
+
+      for (const line of stdoutDec.push(d)) {
+        if (line.includes('Total files: 1')) {
+          tSetupDst.pass('Setup target mirror')
+        }
+
+        if (line.includes('new-file.txt')) {
+          tDstUpdate.pass('Target update detected')
+        }
+      }
+    })
+  }
+
+  await tSetupDst
+
+  // The file isn't yet guaranteed to be written
+  // after the change is logged
+  await new Promise(resolve => setTimeout(resolve, 1000))
+
+  {
+    const fileContent = await fsProm.readFile(
+      path.join(dstDir, 'init-file.txt'),
+      { encoding: 'utf-8' }
+    )
+    t.is(fileContent, 'Just an initial file', 'correctly mirrored file')
+  }
+
+  await fsProm.writeFile(
+    path.join(srcDir, 'new-file.txt'),
+    'file added during mirror'
+  )
+
+  await tSourceUpdate
+  await tDstUpdate
+
+  // The file isn't yet guaranteed to be written
+  // after the change is logged
+  await new Promise(resolve => setTimeout(resolve, 1000))
+
+  {
+    const fileContent = await fsProm.readFile(
+      path.join(dstDir, 'new-file.txt'),
+      { encoding: 'utf-8' }
+    )
+    t.is(fileContent, 'file added during mirror', 'correctly mirrored new file')
+  }
+
+  runSrcProc.kill('SIGKILL')
+  runTgtProc.kill('SIGKILL')
+})
+
+async function setupDrive (storage, t) {
+  const createDriveProc = spawn(EXECUTABLE,
+    ['touch', '--storage', storage]
+  )
+
+  // To avoid zombie processes in case there's an error
+  process.on('exit', () => {
+    if (createDriveProc.exitCode === null) createDriveProc.kill('SIGKILL')
+  })
+
+  let driveKey = null
+  const stdoutDec = new NewlineDecoder('utf-8')
+
+  createDriveProc.stdout.on('data', d => {
+    if (DEBUG) console.log('<setup drive stdout>', d.toString())
+
+    for (const line of stdoutDec.push(d)) {
+      if (line.includes('New drive:')) {
+        driveKey = line.split('New drive: ')[1].slice(0, 64)
+      }
+    }
+  })
+
+  createDriveProc.stderr.on('data', d => {
+    console.error(d.toString())
+    t.fail('stderr output when touching src drive')
+  })
+
+  const [exitCode] = await once(createDriveProc, 'exit')
+  t.is(exitCode, 0, '0 exit code when touching drive')
+  t.not(driveKey, null, 'Got the drive key')
+
+  return driveKey
+}


### PR DESCRIPTION
This PR:
- Uses watch-drive for the watching
- Efficiently processes the changes
- Adds an integration test for the live mirror flow (since that's what this PR works on)

Previous behaviour was to watch for changes, and run a full sync every time there was a change. Starting from 1K files this takes over a second. With this PR it's ~instant, and in theory it should be ~instant even for arbitrary large directories

Marked as draft because I want to sanity check the approach some more, and still need to reason about some edge cases. Particularly:
- It probably needs a check on whether the source changed, like in mirror-drive
- What happens to files added while the initial syncing runs