### PR TITLE
Fix crash in --live mode

### DIFF
--- a/bin/mirror.js
+++ b/bin/mirror.js
@@ -226,7 +226,7 @@ function blobLength (entry) {
 
 // Source: adapted from https://github.com/holepunchto/mirror-drive/blob/037acd7d2566915d43d7dc62b4b30d15522b9df9/index.js#L126-L140
 async function same (srcEntry, dstEntry, srcDrive, dstDrive) {
-  if (!dstEntry) return false
+  if (!srcEntry || !dstEntry) return false
 
   if (srcEntry.value.linkname || dstEntry.value.linkname) {
     return srcEntry.value.linkname === dstEntry.value.linkname


### PR DESCRIPTION
This PR fixes a crash when running --live mode and a file is deleted, causing srcEntry to be null.

Fixes #40 